### PR TITLE
fix(report-to-pdf): fix retrieval of chart's canvasDataUrl in material component

### DIFF
--- a/src/core/reports/report-to-pdf/report-to-pdf.ts
+++ b/src/core/reports/report-to-pdf/report-to-pdf.ts
@@ -57,7 +57,7 @@ const fontsMap = {
 
 export function openReportPdf(report: AjfReportInstance, orientation?: PageOrientation) {
   createReportPdf(report, orientation).then(pdf => {
-    pdf.download();
+    pdf.open();
   });
 }
 

--- a/src/material/reports/chart-widget.html
+++ b/src/material/reports/chart-widget.html
@@ -6,5 +6,7 @@
   <ajf-chart
       [chartType]="instance.chartType"
       [options]="instance.widget.options"
-      [data]="instance.data"></ajf-chart>
+      [data]="instance.data"
+      [instance]="instance">
+  </ajf-chart>
 </ajf-widget-export>


### PR DESCRIPTION
A couple of lines of code got somehow lost in the last pull request, resulting in the charts not being printed correctly. Here's the fix.

Also, openReportPdf should open the pdf, instead of downloading it, as we already do with form printing. Let me know if we want a "downloadReportPdf" function, too.