### PR TITLE
report-to-pdf: set image width from styles

### DIFF
--- a/src/core/reports/report-to-pdf/report-to-pdf.ts
+++ b/src/core/reports/report-to-pdf/report-to-pdf.ts
@@ -157,6 +157,10 @@ function imageToPdf(image: AjfImageWidgetInstance, images: ImageMap, width: numb
   if (dataUrl == null) {
     return {text: ''};
   }
+  const w = image.styles.width;
+  if (typeof(w) === 'string' && w.endsWith('px')) {
+    width = Number(w.slice(0, -2));
+  }
   return {image: dataUrl, width, margin: [0, 0, 0, marginBetweenWidgets]};
 }
 


### PR DESCRIPTION
When printing image widgets, use the width found in "styles" if it's specified in pixels.