### PR TITLE
feat(core/forms): improve form-to-pdf api

### DIFF
--- a/src/dev-app/mat-forms/forms-demo.ts
+++ b/src/dev-app/mat-forms/forms-demo.ts
@@ -98,16 +98,15 @@ export class FormsDemo {
   }
 
   printPdf() {
-    const schema = {
-      name: 'Test Form',
-      schema: this.form$.getValue() as AjfForm,
-      is_tallysheet: false,
-    };
-    const formData = {
-      date_start: ' ',
-      date_end: ' ',
-      data: this._formRendererService.getFormValue(),
-    };
-    createFormPdf(schema, undefined, formData).open();
+    const form = this.form$.getValue() as AjfForm;
+    const ctx = this._formRendererService.getFormValue();
+    const header: any = [{
+      text: 'Test Form',
+      fontSize: 22,
+      bold: true,
+      alignment: 'center',
+      margin: [0, 0, 0, 10]
+    }];
+    createFormPdf(form, undefined, undefined, header, ctx).open();
   }
 }

--- a/tools/public_api_guard/core/forms.d.ts
+++ b/tools/public_api_guard/core/forms.d.ts
@@ -816,7 +816,7 @@ export declare function createFieldWithChoicesInstance<T>(instance: AjfFieldWith
 
 export declare function createForm(form?: AjfFormCreate): AjfForm;
 
-export declare function createFormPdf(formSchema: FormSchema, ts?: TranslateService, formData?: FormData): TCreatedPdf;
+export declare function createFormPdf(form: AjfForm, translate?: (s: string) => string, orientation?: PageOrientation, header?: Content[], context?: AjfContext): TCreatedPdf;
 
 export declare function createNode(node: AjfNodeCreate): AjfNode;
 


### PR DESCRIPTION
This removes dewco-like interfaces from the public api of form-to-pdf.
In particular, FormSchema has been replaced with AjfForm, FormData with AjfContext and additional information such as the form name and date start/end are passed as an header to the pdf.