### PR TITLE
fix(core/reports): omit table header when empty

### DIFF
--- a/src/core/reports/utils/widgets-instances/widget-to-widget-instance.ts
+++ b/src/core/reports/utils/widgets-instances/widget-to-widget-instance.ts
@@ -207,7 +207,7 @@ export function widgetToWidgetInstance(
         colspan: cell.colspan,
       });
     });
-    tdwi.data = [[...header], ...dataset];
+    tdwi.data = header.length === 0 ? [...dataset] : [[...header], ...dataset];
   } else if (widget.widgetType === AjfWidgetType.Image) {
     const iw = widget as AjfImageWidget;
     const iwi = wi as AjfImageWidgetInstance;


### PR DESCRIPTION
The empty header is useless and confuses pdfmake when printing