### PR TITLE
feat(core/reports): html icons to text in csv/xlsx widget export

### DIFF
--- a/src/core/reports/widget-export.ts
+++ b/src/core/reports/widget-export.ts
@@ -43,6 +43,15 @@ export class AjfWidgetExport {
   @Input() overlay = true;
   @Input() enable = false;
 
+  private static _iconsMap: {[html: string]: string} = {};
+
+  /**
+   * Allows rendering html icons as text.
+   */
+  static addIcons(icons: {[html: string]: string}) {
+    AjfWidgetExport._iconsMap = {...AjfWidgetExport._iconsMap, ...icons};
+  }
+
   constructor() {}
 
   /**
@@ -78,6 +87,7 @@ export class AjfWidgetExport {
   }
 
   private _buildXlsxData(): unknown[][] {
+    const iconsMap = AjfWidgetExport._iconsMap;
     let xlsxData: unknown[][] = [];
     let labels: string[] = [];
     switch (this.widgetType) {
@@ -117,7 +127,11 @@ export class AjfWidgetExport {
               isNewRowAfterRowspan = true;
             }
             tableData[i].forEach((elem: AjfTableCell, idxElem: number) => {
-              res.push(elem.value.changingThisBreaksApplicationSecurity);
+              let val = elem.value.changingThisBreaksApplicationSecurity;
+              if (iconsMap[val]) {
+                val = iconsMap[val];
+              }
+              res.push(val);
 
               if (elem.colspan && elem.colspan > 1) {
                 for (let j = 1; j < elem.colspan; j++) {

--- a/src/dev-app/mat-reports/reports-demo.ts
+++ b/src/dev-app/mat-reports/reports-demo.ts
@@ -23,6 +23,7 @@
 import {
   AjfReportInstance,
   AjfReportSerializer,
+  AjfWidgetExport,
   createReportInstance,
   openReportPdf,
 } from '@ajf/core/reports';
@@ -58,6 +59,8 @@ export class ReportsDemo {
     _ts.setTranslation(engDict, 'ENG');
     _ts.setDefaultLang('ENG');
     this._populateReport();
+
+    AjfWidgetExport.addIcons({'3a': '3a export icon!'});
   }
 
   setReport(): void {

--- a/tools/public_api_guard/core/reports.md
+++ b/tools/public_api_guard/core/reports.md
@@ -570,6 +570,9 @@ export type AjfWidgetCreate = Pick<AjfWidget, 'widgetType'> & Partial<AjfWidget>
 // @public (undocumented)
 export class AjfWidgetExport {
     constructor();
+    static addIcons(icons: {
+        [html: string]: string;
+    }): void;
     // (undocumented)
     data: ChartData | AjfTableCell[][];
     // (undocumented)


### PR DESCRIPTION
Allows rendering html icons as text when exporting tables in csv/xlsx