### PR TITLE
feat(core/transloco): support override of default transloco configuration

### DIFF
--- a/projects/core/cypress/integration/transloco.spec.ts
+++ b/projects/core/cypress/integration/transloco.spec.ts
@@ -1,0 +1,22 @@
+import {ENG} from '../../transloco/src/eng';
+import {FRA} from '../../transloco/src/fra';
+
+const origStrings = Object.keys(ENG).slice(0, 10);
+const trnStrings = origStrings.map(str => FRA[str]);
+
+describe('transloco', () => {
+  beforeEach(() => cy.visit('/transloco'));
+
+  it('should support override of the default transloco configuration', () => {
+    const strNum = origStrings.length;
+    cy.get('.test-string').should('have.length', strNum);
+    for (let i = 0; i < strNum; i++) {
+      cy.get(`.test-string:nth-of-type(${i + 1})`).should('have.text', origStrings[i]);
+    }
+    cy.get('mat-select').click();
+    cy.get('mat-option:contains("FRA")').click();
+    for (let i = 0; i < strNum; i++) {
+      cy.get(`.test-string:nth-of-type(${i + 1})`).should('have.text', trnStrings[i]);
+    }
+  });
+});

--- a/projects/core/reports/src/report-instances.spec.ts
+++ b/projects/core/reports/src/report-instances.spec.ts
@@ -35,8 +35,8 @@ describe('createReportInstance', () => {
   let ts: TranslocoService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({imports: [AjfTranslocoModule]});
-    ts = TestBed.get(TranslocoService);
+    TestBed.configureTestingModule({imports: [AjfTranslocoModule.forRoot()]});
+    ts = TestBed.inject(TranslocoService);
   });
 
   it('should support variables at report level', () => {

--- a/projects/core/transloco/src/transloco.module.ts
+++ b/projects/core/transloco/src/transloco.module.ts
@@ -25,6 +25,7 @@ import {
   TRANSLOCO_CONFIG,
   TRANSLOCO_MISSING_HANDLER,
   translocoConfig,
+  TranslocoConfig,
   TranslocoModule,
   TranslocoService,
   TRANSLOCO_TRANSPILER,
@@ -33,19 +34,13 @@ import {
 
 import {langs} from './lang';
 import {MissingHandler} from './transloco-missing-handler';
+
 const availableLangs = ['ENG', 'ESP', 'FRA', 'ITA', 'PRT', 'ETH'];
+
 @NgModule({
   imports: [TranslocoModule],
   exports: [TranslocoModule],
   providers: [
-    {
-      provide: TRANSLOCO_CONFIG,
-      useValue: translocoConfig({
-        availableLangs,
-        defaultLang: 'ENG',
-        prodMode: false,
-      }),
-    },
     {provide: TRANSLOCO_MISSING_HANDLER, useClass: MissingHandler},
     {
       provide: TRANSLOCO_TRANSPILER,
@@ -61,10 +56,23 @@ export class AjfTranslocoModule {
       }
     });
   }
-  static forRoot(): ModuleWithProviders<AjfTranslocoModule> {
+
+  static forRoot(
+    config?: Partial<TranslocoConfig> | undefined,
+  ): ModuleWithProviders<AjfTranslocoModule> {
     return {
       ngModule: AjfTranslocoModule,
-      providers: [TranslocoService],
+      providers: [
+        TranslocoService,
+        {
+          provide: TRANSLOCO_CONFIG,
+          useValue: translocoConfig({
+            ...config,
+            availableLangs,
+            defaultLang: 'ENG',
+          }),
+        },
+      ],
     };
   }
 }

--- a/projects/e2e-app/src/e2e-app/e2e-app-layout.ts
+++ b/projects/e2e-app/src/e2e-app/e2e-app-layout.ts
@@ -13,6 +13,7 @@ export class E2eAppLayout {
 
   navLinks = [
     {path: 'file-input', title: 'File Input'},
+    {path: 'transloco', title: 'Transloco'},
     {path: 'ion-calendar', title: 'Ionic - Calendar'},
     {path: 'ion-date-input-field', title: 'Ionic - Date Input Field'},
     {path: 'ion-form', title: 'Ionic - Form'},

--- a/projects/e2e-app/src/main-module.ts
+++ b/projects/e2e-app/src/main-module.ts
@@ -19,6 +19,7 @@ import {MaterialDateInputFieldE2eModule} from './mat-date-input-field/date-input
 import {MaterialFormE2eModule} from './mat-form/mat-form-e2e.module';
 import {MaterialReportE2eModule} from './mat-report/mat-report-e2e.module';
 import {MaterialTableFieldE2eModule} from './mat-table-field/table-field-e2e-module';
+import {TranslocoE2eModule} from './transloco/transloco-e2e-module';
 
 @NgModule({
   imports: [
@@ -41,6 +42,7 @@ import {MaterialTableFieldE2eModule} from './mat-table-field/table-field-e2e-mod
     MaterialReportE2eModule,
     MaterialTableFieldE2eModule,
     MaterialFormE2eModule,
+    TranslocoE2eModule,
   ],
   declarations: [E2eApp],
   bootstrap: [E2eApp],

--- a/projects/e2e-app/src/routes.ts
+++ b/projects/e2e-app/src/routes.ts
@@ -12,10 +12,12 @@ import {MaterialDateInputFieldE2E} from './mat-date-input-field/date-input-field
 import {MaterialFormE2E} from './mat-form/mat-form-e2e';
 import {MaterialReportE2E} from './mat-report/mat-report-e2e';
 import {MaterialTableFieldE2E} from './mat-table-field/table-field-e2e';
+import {TranslocoE2E} from './transloco/transloco-e2e';
 
 export const E2E_APP_ROUTES: Routes = [
   {path: '', component: Home},
   {path: 'file-input', component: FileInputE2E},
+  {path: 'transloco', component: TranslocoE2E},
   {path: 'ion-calendar', component: IonicCalendarE2E},
   {path: 'ion-date-input-field', component: IonicDateInputFieldE2E},
   {path: 'ion-form', component: IonicFormE2E},

--- a/projects/e2e-app/src/transloco/transloco-e2e-module.ts
+++ b/projects/e2e-app/src/transloco/transloco-e2e-module.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright (C) Gnucoop soc. coop.
+ *
+ * This file is part of the Advanced JSON forms (ajf).
+ *
+ * Advanced JSON forms (ajf) is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * Advanced JSON forms (ajf) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Advanced JSON forms (ajf).
+ * If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {AjfTranslocoModule} from '@ajf/core/transloco';
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatSelectModule} from '@angular/material/select';
+import {TranslocoE2E} from './transloco-e2e';
+
+@NgModule({
+  imports: [
+    AjfTranslocoModule.forRoot({reRenderOnLangChange: true}),
+    CommonModule,
+    MatFormFieldModule,
+    MatSelectModule,
+  ],
+  declarations: [TranslocoE2E],
+})
+export class TranslocoE2eModule {}

--- a/projects/e2e-app/src/transloco/transloco-e2e.html
+++ b/projects/e2e-app/src/transloco/transloco-e2e.html
@@ -1,0 +1,10 @@
+<h1>Transloco Example</h1>
+<section>
+  <mat-form-field>
+    <mat-label>Select a language</mat-label>
+    <mat-select (selectionChange)="selectLang($event)" [value]="langs[0]">
+      <mat-option *ngFor="let lang of langs" [value]="lang">{{ lang }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+  <div *ngFor="let str of strings" class="test-string">{{ str|transloco }}</div>
+</section>

--- a/projects/e2e-app/src/transloco/transloco-e2e.ts
+++ b/projects/e2e-app/src/transloco/transloco-e2e.ts
@@ -1,0 +1,19 @@
+import {langs} from '@ajf/core/transloco';
+import {Component} from '@angular/core';
+import {MatSelectChange} from '@angular/material/select';
+import {TranslocoService} from '@ngneat/transloco';
+
+@Component({
+  selector: 'transloco-e2e',
+  templateUrl: 'transloco-e2e.html',
+})
+export class TranslocoE2E {
+  readonly langs = Object.keys(langs);
+  readonly strings = Object.keys(langs['ENG']).slice(0, 10);
+
+  constructor(private service: TranslocoService) {}
+
+  selectLang(evt: MatSelectChange) {
+    this.service.setActiveLang(evt.value);
+  }
+}

--- a/projects/ionic/forms/src/form-read-only.spec.ts
+++ b/projects/ionic/forms/src/form-read-only.spec.ts
@@ -32,7 +32,7 @@ import {AjfFormsModule} from './public_api';
 describe('AjfFormRenderer', () => {
   beforeEach(async () => {
     TestBed.configureTestingModule({
-      imports: [AjfFormsModule, NoopAnimationsModule, AjfTranslocoModule],
+      imports: [AjfFormsModule, NoopAnimationsModule, AjfTranslocoModule.forRoot()],
       declarations: [TestComponent],
     });
     await TestBed.compileComponents();

--- a/projects/material/forms/src/form-read-only.spec.ts
+++ b/projects/material/forms/src/form-read-only.spec.ts
@@ -41,7 +41,7 @@ import {AjfFormsModule} from './public_api';
 describe('AjfFormRenderer', () => {
   beforeEach(async () => {
     TestBed.configureTestingModule({
-      imports: [AjfFormsModule, NoopAnimationsModule, AjfTranslocoModule],
+      imports: [AjfFormsModule, NoopAnimationsModule, AjfTranslocoModule.forRoot()],
       declarations: [
         TestComponent,
         TestReadOnlySingleChoiceComponent,


### PR DESCRIPTION
Re-render on lang change is not active in default Transloco Module configuration, should be better to provide a mechanism to override the default transloco configuration, in order to activate it.
