### PR TITLE
fix(core/reports): widget.options misspell in widgetToWidgetInstance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log
 /connect.lock
 /coverage
 /libpeerconnection.log
+.ng-dev.log
 testem.log
 /typings
 **/cypress/downloads

--- a/projects/core/reports/src/utils/widgets-instances/widget-to-widget-instance.ts
+++ b/projects/core/reports/src/utils/widgets-instances/widget-to-widget-instance.ts
@@ -81,8 +81,8 @@ export function widgetToWidgetInstance(
       wi.content = content;
     });
   } else if (isChartWidget(widget) && isChartWidgetInstance(wi)) {
-    if ((widget as any).option == null) {
-      (widget as any).option = {};
+    if (widget.options == null) {
+      widget.options = {};
     }
     const labels = widget.labels instanceof Array ? widget.labels : [widget.labels];
     const evLabels = labels.map(l => {


### PR DESCRIPTION
As a bonus, I added .ng-dev.log to gitignore.