### PR TITLE
fix(core/reports): enable variables in indicator expressions

### DIFF
--- a/projects/core/reports/src/xls-report/hindikit-parser.spec.ts
+++ b/projects/core/reports/src/xls-report/hindikit-parser.spec.ts
@@ -1,0 +1,21 @@
+import {indicatorToJs} from './hindikit-parser';
+
+describe('indicatorToJs', () => {
+  const indicator1 = 'SUM(forms, $pippo, $name = pluto)';
+  it(indicator1, () => {
+    const result = indicatorToJs(indicator1);
+    expect(result).toBe('SUM.call({pluto}, forms, "pippo", "name === pluto")');
+  });
+
+  const indicator2 = 'SUM(forms, $pippo)';
+  it(indicator2, () => {
+    const result = indicatorToJs(indicator2);
+    expect(result).toBe('SUM(forms, "pippo")');
+  });
+
+  const indicator3 = '[forms[0], 4+(5), IF_THEN_ELSE(foo, pippo, pluto)]';
+  it(indicator3, () => {
+    const result = indicatorToJs(indicator3);
+    expect(result).toBe('[forms[0], 4 + (5), (foo ? pippo : pluto)]');
+  });
+});


### PR DESCRIPTION
Uso l'oggetto this come context per passare le variabili alle funzioni tipo SUM. Il parser si preoccupa di tenere traccia di quali sono gli identificatori usati nelle espressioni e di costruire la chiamata di funzione appropriata.