### PR TITLE
feat(core/forms): customizable notEmpty message

### DIFF
--- a/projects/core/forms/src/utils/validation/evaluate-validation-not-empty.ts
+++ b/projects/core/forms/src/utils/validation/evaluate-validation-not-empty.ts
@@ -20,7 +20,8 @@
  *
  */
 
-import {evaluateExpression} from '@ajf/core/models';
+import {notEmpty} from '@ajf/core/models';
+import {AjfValidation} from '../../interface/validation/validation';
 import {AjfValidationGroup} from '../../interface/validation/validation-group';
 import {AjfValidationResult} from '../../interface/validation/validation-results';
 import {evaluateValidation} from './evaluate-validation';
@@ -33,16 +34,19 @@ export function evaluateValidationNotEmpty(
   validation: AjfValidationGroup,
   value: any,
 ): AjfValidationResult | null {
-  if (validation.notEmpty == null) {
+  let ne = validation.notEmpty as AjfValidation | boolean | string | undefined;
+  if (ne == null || ne === false) {
     return null;
   }
-  const ctx = {'$value': value};
-  if (typeof validation.notEmpty === 'boolean') {
+  if (ne === true) {
+    ne = 'Value must not be empty';
+  }
+  if (typeof ne === 'string') {
     return {
-      result: evaluateExpression(`notEmpty($value) === ${validation.notEmpty}`, ctx),
-      error: 'Value must not be empty',
+      result: notEmpty(value),
+      error: ne,
       clientValidation: false,
     };
   }
-  return evaluateValidation(validation.notEmpty, ctx);
+  return evaluateValidation(ne as AjfValidation, {'$value': value});
 }

--- a/projects/core/models/src/utils/expression-utils.ts
+++ b/projects/core/models/src/utils/expression-utils.ts
@@ -322,7 +322,7 @@ export function isInt(x: string | number): boolean {
  * It is true if x is not empty.
  */
 export function notEmpty(x: any): boolean {
-  return typeof x !== 'undefined' && x !== null ? x.toString().length > 0 : false;
+  return !(x == null || x === '');
 }
 /**
  * It is true if array contains x or array is equal to x.

--- a/projects/ionic/forms/src/forms.spec.ts
+++ b/projects/ionic/forms/src/forms.spec.ts
@@ -71,7 +71,7 @@ describe('AjfFormRenderer', () => {
               label: 'foo',
               nodeType: AjfNodeType.AjfField,
               fieldType: AjfFieldType.String,
-              validation: {notEmpty: true},
+              validation: {notEmpty: "The field's value must not be empty."},
             } as any,
           ],
         },


### PR DESCRIPTION
Nel form schema,
validation: {notEmpty: true}

Può diventare
validation: {notEmpty: "Il valore must not be empto!!"}

Per specificare un messaggio di errore custom.